### PR TITLE
Custom HTML5 Web Components and value attribute

### DIFF
--- a/dist/lemonade.js
+++ b/dist/lemonade.js
@@ -140,7 +140,7 @@
                     e.innerHTML = v;
                 }
             } else {
-                e.value = v;
+                e.setAttribute(t, v);
             }
         } else if (t == '@src') {
             if (! v) {


### PR DESCRIPTION
I created this components [library](https://github.com/lucianoiam/guinda). The components support a value attribute like a standard `<input>`. Seems like LemonadeJS is giving some special treatment to this attribute and my custom components always render an empty string as the value instead of the actual value. For example:

`<g-knob value="{{self.gainValue}}"></g-knob>`

`self.gainValue = 0.25`

Always renders to:

`<g-knob value=""></g-knob>`

This patch fixes the issue by replicating the fallback code path in setAttribute() when the attribute key is 'value' and the element is neither a select, checkbox, radio, etc.
 