### PR TITLE
Compatibility with custom HTML5 Web Components

### DIFF
--- a/dist/lemonade.js
+++ b/dist/lemonade.js
@@ -651,16 +651,7 @@
             // Parse fragment
             t = t.replace(/<>/gi, "<root>").replace(/<\/>/gi, "<\/root>").trim();
             // Create the root element
-            var el = document.createElement('template');
-            // Get the DOM content
-            el.innerHTML = t;
-            // Extract
-            if (el.content) {
-                el = el.content;
-            } else {
-                el = document.createElement('div');
-                el.innerHTML = t;
-            }
+            var el = document.createRange().createContextualFragment(t);
 
             // Already single DOM, do not need a container
             if (el.childNodes.length > 1) {


### PR DESCRIPTION
This JSFiddle shows why the `<template>` method breaks Web Components https://jsfiddle.net/h38md92L/

The patch makes LemonadeJS rely on `createContextualFragment()` instead of creating templates. It also saves a couple LOCs.

Further discussion at https://github.com/lemonadejs/lemonadejs/pull/31

Feel free to merge or reject
