### PR TITLE
Clarifying that Arrays use Objects

### DIFF
--- a/docs/arrays.md
+++ b/docs/arrays.md
@@ -7,7 +7,11 @@ description: Generate lists of elements from arrays using the loop attribute.
 Arrays
 ======
 
-The `:loop` attribute in LemonadeJS is a powerful tool for dynamically creating lists of elements, such as product listings or data grids, in the user interface. It works by iterating over an array of objects and using a template string to define how each element should be represented as a DOM element. This section will explore advanced features such as implementing search functionality that allows the list to be updated in real-time as new elements are added, or existing ones are filtered. That facilitates the creation of highly interactive and responsive interfaces where users can interact with complex datasets efficiently. 
+The `:loop` attribute in LemonadeJS is a powerful tool for dynamically creating lists of elements, such as product listings or data grids, in the user interface. 
+
+It works by iterating over an array of objects and using a template string to define how each element should be represented as a DOM element. 
+
+This section will explore advanced features such as implementing search functionality that allows the list to be updated in real-time as new elements are added, or existing ones are filtered. That facilitates the creation of highly interactive and responsive interfaces where users can interact with complex datasets efficiently. 
 
 > **Summary of this chapter**
 >


### PR DESCRIPTION
When getting started I passed an array of strings to the `:loop` attribute.

As in: 
``` javascript
function () {
    const self = this;

    ${/* Defining an array of strings instead of objects */''}
    self.names = [ 'Marie', 'Grace', 'Annie'];

    self.description = "was a scientist";

    return `<ul :loop="self.names">
        <li>
    ${/* Referencing self returns a name */''}
            <h2>{{self}}</h2>

    ${/* Referencing self.parent will return undefined */''}
            <p>{{self.parent.description}}</p>
        </li>
    </ul>`;
}
```

My error was that I did not understand that **`:loop` specifically requires an array of objects** in order to append the `.parent` and `.el` attributes.

---

This pull request edits the docs to make it more apparent. I don't think that an alert-box is necessary, but a couple line-breaks would be helpful.